### PR TITLE
Use a newer upstream for xr_usb_common

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Once you connect ollie to a Windows machine, you should be able to see 4 COM por
 
 #### Linux
 On Linux you should see four devices created, typically /dev/ttyXRUSB[0-3]. If you see /dev/ttyACM[0-3], there is a chance the UART might not behave correctly in this case you need to install drivers by following these steps:
-1. \# git clone https://github.com/brendanhoran/xr_usb_serial_common-1a
+1. \# git clone https://github.com/brendanhoran/xr_usb_serial_common
 2. \# make *(on raspberry pi make sure you have the [kernel headers](https://www.raspberrypi.org/documentation/linux/kernel/headers.md) installed)*
 3. \# cp -a ../xr_usb_serial_common-1a /usr/src/
 4. \# dkms add -m xr_usb_serial_common -v 1a

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Once you connect ollie to a Windows machine, you should be able to see 4 COM por
 
 #### Linux
 On Linux you should see four devices created, typically /dev/ttyXRUSB[0-3]. If you see /dev/ttyACM[0-3], there is a chance the UART might not behave correctly in this case you need to install drivers by following these steps:
-1. \# git clone https://github.com/niosHD/xr_usb_serial_common-1c
+1. \# git clone https://github.com/brendanhoran/xr_usb_serial_common-1a
 2. \# make *(on raspberry pi make sure you have the [kernel headers](https://www.raspberrypi.org/documentation/linux/kernel/headers.md) installed)*
 3. \# cp -a ../xr_usb_serial_common-1a /usr/src/
 4. \# dkms add -m xr_usb_serial_common -v 1a


### PR DESCRIPTION
I have updated the kernel module to version 1C 
Taken from upstream at:
https://www.maxlinear.com/support/design-tools/software-drivers

I have also fixed all compile errors for kernel 5.x 
Some warnings remain but the module works fine.

I plan to keep this update with upstream and any kernel changes.